### PR TITLE
Optional user/password and /ovirt-engine/api HTTP authentication plus minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Role Variables
 * aaa_ldap: List of ldap servers. If more servers is specified failover policy will be used.
 * aaa_base_dn: Custom base DN in case user want to set special.
 * aaa_sso_keytab: Path to keytab which store principal to use SSO. This parameter is required in case SSO should be deployed.
+* aaa_legacy_api_authn: Whether to include `/ovirt-engine/api` among paths that trigger HTTP authentication (was necessary before oVirt 4.0). Disabled by default
 
 For example to obtain HTTP keytab for oVirt engine in IPA use following command
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Role Name
-=========
+oVirt AAA LDAP
+==============
 
 This role deploy oVirt AAA LDAP configuration.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 # defaults file for aaa-ldap-setup
+aaa_legacy_api_authn: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -78,7 +78,11 @@
     - restart httpd
 
 - name: Test AAA profile
-  shell: /usr/bin/ovirt-engine-extensions-tool --extension-file=/etc/ovirt-engine/extensions.d/{{ aaa_profile_name }}-authn.properties --extension-file=/etc/ovirt-engine/extensions.d/{{ aaa_profile_name }}-authz.properties aaa search --extension-name={{ aaa_profile_name }}-authz
-  failed_when: "0 != tool_result.rc"
-  changed_when: "1 == 2"
-  register: tool_result
+  command: >
+    /usr/bin/ovirt-engine-extensions-tool
+    --extension-file=/etc/ovirt-engine/extensions.d/{{
+    aaa_profile_name | quote }}-authn.properties
+    --extension-file=/etc/ovirt-engine/extensions.d/{{
+    aaa_profile_name | quote }}-authz.properties aaa search
+    --extension-name={{ aaa_profile_name | quote }}-authz
+  changed_when: false

--- a/templates/profile
+++ b/templates/profile
@@ -1,10 +1,18 @@
 include = <{{ aaa_profile_type }}.properties>
 
+{% if aaa_user is defined %}
 vars.user = {{ aaa_user }}
+{% endif %}
+{% if aaa_password is defined %}
 vars.password = {{ aaa_password }}
+{% endif %}
 
+{% if aaa_user is defined %}
 pool.default.auth.simple.bindDN = ${global:vars.user}
+{% endif %}
+{% if aaa_password is defined %}
 pool.default.auth.simple.password = ${global:vars.password}
+{% endif %}
 {# ----------------- SRV record ----------------- #}
 {% if aaa_profile_type == "ad" %}
 pool.default.serverset.type = srvrecord

--- a/templates/sso
+++ b/templates/sso
@@ -1,4 +1,4 @@
-<LocationMatch ^/ovirt-engine/sso/(interactive-login-negotiate|oauth/token-http-auth)|^/ovirt-engine/api>
+<LocationMatch ^/ovirt-engine/sso/(interactive-login-negotiate|oauth/token-http-auth){% if aaa_legacy_api_authn %}|^/ovirt-engine/api{% endif %}>
   <If "req('Authorization') !~ /^(Bearer|Basic)/i">
     RewriteEngine on
     RewriteCond %{LA-U:REMOTE_USER} ^(.*)$


### PR DESCRIPTION
# Update of Test AAA profile task:
* called shell module without use of shell features. Switched to command
  module instead
* used single very long line, which is now broken to shorter ones
* now uses quote filter to avoid injection issues
* ansible marks task as failed when return code != 0, no need (now?) to
  register result and test for result.rc != 0
* we can write false boolean in changed_when as just ‘false’

#  Make authn user and password optional 
Some LDAP servers don't require authentication at all, some authentication methods (kerberos with keytab) don't need username or password. This commit makes aaa_user and aaa_password optional.

#  Make HTTP authn of API path optional and omitted by default 
HTTP authentication on /ovirt-engine/api and /api paths was only required in oVirt < 4.0. oVirt 4.0 was released 3.5 years ago and this backward-compatibility setting prevents use of mixed authentication mechanisms for API (username/password for internal users and kerberos for LDAP ones).

Given that current setting is obsolete for such a long time and that it limits available features, I decided to make it disabled by default