### PR TITLE
Add option for keytab already present on OE host

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Role Variables
 * aaa_user: User which should be used to search users for auhtorization.
 * aaa_password: Password of the search user.
 * aaa_profile_name: Name of the profile (visible in login page).
-* aaa_ldap: List of ldap servers. If more servers is specified failover policy will be used.
+* aaa_ldap: List of LDAP servers or LDAP domain. When more servers are specified, failover policy will be used.
+* aaa_ldap_is_domain: Whether aaa_ldap is domain with servers discovered via SRV records or not. Default is false (with exception of aaa_profile_type set to `ad`, then default is true)
 * aaa_base_dn: Custom base DN in case user want to set special.
-* aaa_sso_keytab: Path to keytab which store principal to use SSO. This parameter is required in case SSO should be deployed.
 * aaa_legacy_api_authn: Whether to include `/ovirt-engine/api` among paths that trigger HTTP authentication (was necessary before oVirt 4.0). Disabled by default
 * aaa_sso_keytab: Path to keytab on ansible control machine which stores principal to use for SSO. This parameter or aaa_sso_remote_keytab is required in case SSO should be deployed. Keytab will be copied to `/etc/httpd/http.keytab`
 * aaa_sso_remote_keytab: Path to keytab already present on target machine. Must be accessible and readable by apache.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Role Variables
 * aaa_base_dn: Custom base DN in case user want to set special.
 * aaa_sso_keytab: Path to keytab which store principal to use SSO. This parameter is required in case SSO should be deployed.
 * aaa_legacy_api_authn: Whether to include `/ovirt-engine/api` among paths that trigger HTTP authentication (was necessary before oVirt 4.0). Disabled by default
+* aaa_sso_keytab: Path to keytab on ansible control machine which stores principal to use for SSO. This parameter or aaa_sso_remote_keytab is required in case SSO should be deployed. Keytab will be copied to `/etc/httpd/http.keytab`
+* aaa_sso_remote_keytab: Path to keytab already present on target machine. Must be accessible and readable by apache.
 
 For example to obtain HTTP keytab for oVirt engine in IPA use following command
 ```bash

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,4 @@
 aaa_legacy_api_authn: false
 aaa_krb5: false
 aaa_sso_keytab_path: "/etc/httpd/httpd.keytab"
+aaa_ldap_is_domain: "{{ true if aaa_profile_type == 'ad' else false }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 # defaults file for aaa-ldap-setup
 aaa_legacy_api_authn: false
+aaa_krb5: false
+aaa_sso_keytab_path: "/etc/httpd/httpd.keytab"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,21 @@
 ---
+- name: are we configuring kerberos?
+  set_fact:
+    aaa_sso_krb5: true
+  when: aaa_sso_keytab is defined or aaa_sso_remote_keytab is defined
+
+- name: assert we don't have aaa_sso_keytab and aaa_sso_remote_keytab together
+  assert:
+    that: aaa_sso_remote_keytab is not defined
+    msg: >
+      Variables aaa_sso_keytab and aaa_sso_remote_keytab are mutually exclusive
+  when: aaa_sso_keytab is defined
+
+- name: set up remote keytab path
+  set_fact:
+    aaa_sso_keytab_path: "{{ aaa_sso_remote_keytab }}"
+  when: aaa_sso_remote_keytab is defined
+
 - name: Install AAA packages
   yum:
     name: ovirt-engine-extension-aaa-*
@@ -8,7 +25,7 @@
   yum:
     name: mod_auth_gssapi
     state: present
-  when: aaa_sso_keytab is defined
+  when: aaa_sso_krb5
 
 - name: Deploy profile
   template:
@@ -25,7 +42,7 @@
     dest: /etc/ovirt-engine/extensions.d/{{ aaa_profile_name }}-authn.properties
   notify:
     - restart ovirt-engine
-  when: aaa_sso_keytab is undefined
+  when: not aaa_sso_krb5
 
 - name: Deploy http authn
   template:
@@ -33,7 +50,7 @@
     dest: /etc/ovirt-engine/extensions.d/{{ aaa_profile_name }}-http-authn.properties
   notify:
     - restart ovirt-engine
-  when: aaa_sso_keytab is defined
+  when: aaa_sso_krb5
 
 - name: Deploy http mapping
   template:
@@ -41,7 +58,7 @@
     dest: /etc/ovirt-engine/extensions.d/{{ aaa_profile_name }}-http-mapping.properties
   notify:
     - restart ovirt-engine
-  when: aaa_sso_keytab is defined
+  when: aaa_sso_krb5
 
 - name: Deploy authz
   template:
@@ -53,7 +70,7 @@
 - name: Copy keytab
   copy:
     src: "{{ aaa_sso_keytab }}"
-    dest: /etc/httpd/httpd.keytab
+    dest: "{{ aaa_sso_keytab_path }}"
     owner: apache
     mode: 0600
   when: aaa_sso_keytab is defined
@@ -64,7 +81,7 @@
   template:
     src: sso
     dest: /etc/ovirt-engine/aaa/ovirt-sso.conf
-  when: aaa_sso_keytab is defined
+  when: aaa_sso_krb5
   notify:
     - restart httpd
 
@@ -73,7 +90,7 @@
     src: /etc/ovirt-engine/aaa/ovirt-sso.conf
     dest: /etc/httpd/conf.d/ovirt-sso.conf
     state: link
-  when: aaa_sso_keytab is defined
+  when: aaa_sso_krb5 is defined
   notify:
     - restart httpd
 

--- a/templates/profile
+++ b/templates/profile
@@ -14,7 +14,7 @@ pool.default.auth.simple.bindDN = ${global:vars.user}
 pool.default.auth.simple.password = ${global:vars.password}
 {% endif %}
 {# ----------------- SRV record ----------------- #}
-{% if aaa_profile_type == "ad" %}
+{% if aaa_ldap_is_domain %}
 pool.default.serverset.type = srvrecord
 pool.default.serverset.srvrecord.domain = {{ aaa_ldap[0] }}
 {# -------------------- AD SITE ----------------- #}
@@ -26,13 +26,13 @@ pool.default.serverset.srvrecord.domain-conversion.regex.replacement = {{ aaa_ad
 {% endif %}
 {# --------------------------------------------- #}
 {# ------------------ Single ------------------- #}
-{% if aaa_ldap|length == 1 %}
+{% if not aaa_ldap_is_domain and aaa_ldap|length == 1 %}
 pool.default.serverset.type = single
 pool.default.serverset.single.server = {{ aaa_ldap[0] }}
 {% endif %}
 {# --------------------------------------------- #}
 {# ------------ failover ----------------------- #}
-{% if aaa_ldap|length > 1 %}
+{% if not aaa_ldap_is_domain and aaa_ldap|length > 1 %}
 pool.default.serverset.type = failover
 {% for ldap in aaa_ldap %}
 pool.default.serverset.failover.0{{loop.index}}.server = {{ ldap }}

--- a/templates/sso
+++ b/templates/sso
@@ -8,7 +8,7 @@
     AuthType GSSAPI
     AuthName "Kerberos Login"
 
-    GssapiCredStore keytab:/etc/httpd/httpd.keytab
+    GssapiCredStore keytab:{{ aaa_sso_keytab_path }}
     GssapiUseSessions On
    
     Require valid-user


### PR DESCRIPTION
Current aaa_sso_keytab option expects keytab to be copied on ansible
control machine. This commit adds new option aaa_sso_remote_keytab that
expects path to keytab that already exists on target machine. Remote
keytab must already have correct ownership and permissions set.

Another option is added - aaa_soo_keytab_path - which is used internally to
set the keytab path in ovirt-sso.conf. It can be also used to alter
destination for keytab copied from control machine but I decided not to
document it.