### PR TITLE
Kerberos authentication of LDAP queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Role Variables
 * aaa_sso_remote_keytab: Path to keytab already present on target machine. Must be accessible and readable by apache.
 * aaa_jaas_krb5_conf_path: When ovirt-engine authenticates itself on LDAP via kerberos, it will search kerberos configuration at this path. When not set, AAA will default to `/etc/ovirt-engine/krb5.conf`
 * aaa_jaas_ticket_cache_path: Path to ticket cache when engine queries of LDAP server are to be authenticated by GSSAPI with ticket gained from keytab
-* aaa_jaas_keytab_path: Path to keytab when engine queries of LDAP server are to be authenticated by GSSAPI with ticket gained from keytab
+* aaa_jaas_keytab_path: Path to keytab when engine queries of LDAP server are to be authenticated by GSSAPI with ticket gained from keytab. Keytab has to be readable by `ovirt` user
 * aaa_jaas_keytab_principal: Principal that AAA should use to authenticate when querying LDAP server
 
 For example to obtain HTTP keytab for oVirt engine in IPA use following command

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Role Variables
 * aaa_legacy_api_authn: Whether to include `/ovirt-engine/api` among paths that trigger HTTP authentication (was necessary before oVirt 4.0). Disabled by default
 * aaa_sso_keytab: Path to keytab on ansible control machine which stores principal to use for SSO. This parameter or aaa_sso_remote_keytab is required in case SSO should be deployed. Keytab will be copied to `/etc/httpd/http.keytab`
 * aaa_sso_remote_keytab: Path to keytab already present on target machine. Must be accessible and readable by apache.
+* aaa_jaas_krb5_conf_path: When ovirt-engine authenticates itself on LDAP via kerberos, it will search kerberos configuration at this path. When not set, AAA will default to `/etc/ovirt-engine/krb5.conf`
+* aaa_jaas_ticket_cache_path: Path to ticket cache when engine queries of LDAP server are to be authenticated by GSSAPI with ticket gained from keytab
+* aaa_jaas_keytab_path: Path to keytab when engine queries of LDAP server are to be authenticated by GSSAPI with ticket gained from keytab
 
 For example to obtain HTTP keytab for oVirt engine in IPA use following command
 ```bash

--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ This example shows configuration for host that is joined to IPA so global `/etc/
         aaa_jaas_krb5_conf_path: /etc/krb5.conf
         aaa_jaas_keytab_path: "{{ keytab_path }}"
         aaa_jaas_keytab_principal: "{{ lookup('pipe', 'klist -kt ' +
-          keytab_path + ' | grep \'@\' | awk \'{ print $4 };\' | tail -n1') }}"
+          keytab_path +
+          ' | grep ''@'' | tail -n1 | sed -e s/^.*[[:space:]]// ') }}"
       roles:
         - machacekondra.ovirt-aaa-ldap
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Role Variables
 * aaa_jaas_krb5_conf_path: When ovirt-engine authenticates itself on LDAP via kerberos, it will search kerberos configuration at this path. When not set, AAA will default to `/etc/ovirt-engine/krb5.conf`
 * aaa_jaas_ticket_cache_path: Path to ticket cache when engine queries of LDAP server are to be authenticated by GSSAPI with ticket gained from keytab
 * aaa_jaas_keytab_path: Path to keytab when engine queries of LDAP server are to be authenticated by GSSAPI with ticket gained from keytab
+* aaa_jaas_keytab_principal: Principal that AAA should use to authenticate when querying LDAP server
 
 For example to obtain HTTP keytab for oVirt engine in IPA use following command
 ```bash

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,11 @@
 ---
 # defaults file for aaa-ldap-setup
 aaa_legacy_api_authn: false
+aaa_pkgs:
+  - ovirt-engine-extension-aaa-ldap
+aaa_pkgs_krb5:
+  - ovirt-engine-extension-aaa-misc
+  - mod_auth_gssapi
 aaa_krb5: false
 aaa_sso_keytab_path: "/etc/httpd/httpd.keytab"
 aaa_ldap_is_domain: "{{ true if aaa_profile_type == 'ad' else false }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,6 +67,15 @@
   notify:
     - restart ovirt-engine
 
+- name: Deploy JAAS
+  template:
+    src: jaas
+    dest: /etc/ovirt-engine/engine.conf.d/99-jaas.conf
+  notify:
+    - restart ovirt-engine
+  when: (ovirt_jaas_ticket_cache_path is defined or
+          ovirt_jaas_keytab_path is defined)
+
 - name: Copy keytab
   copy:
     src: "{{ aaa_sso_keytab }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: are we configuring kerberos?
   set_fact:
     aaa_sso_krb5: true
+    aaa_pkgs: "{{ aaa_pkgs | union(aaa_pkgs_krb5) }}"
   when: aaa_sso_keytab is defined or aaa_sso_remote_keytab is defined
 
 - name: assert we don't have aaa_sso_keytab and aaa_sso_remote_keytab together
@@ -17,15 +18,9 @@
   when: aaa_sso_remote_keytab is defined
 
 - name: Install AAA packages
-  yum:
-    name: ovirt-engine-extension-aaa-*
+  package:
+    name: "{{ aaa_pkgs }}"
     state: present
-
-- name: Install mod_auth_gssapi
-  yum:
-    name: mod_auth_gssapi
-    state: present
-  when: aaa_sso_krb5
 
 - name: Deploy profile
   template:

--- a/templates/jaas
+++ b/templates/jaas
@@ -8,4 +8,7 @@ AAA_JAAS_TICKET_CACHE_FILE={{ aaa_jaas_ticket_cache_path }}
 {% if aaa_jaas_keytab_path is defined %}
 AAA_JAAS_USE_KEYTAB=true
 AAA_JAAS_KEYTAB_FILE={{ aaa_jaas_keytab_path }}
+{% if aaa_jaas_keytab_principal is defined %}
+AAA_JAAS_PRINCIPAL_NAME={{ aaa_jaas_keytab_principal }}
+{% endif %}
 {% endif %}

--- a/templates/jaas
+++ b/templates/jaas
@@ -1,0 +1,11 @@
+{% if aaa_jaas_krb5_conf_path is defined %}
+AAA_KRB5_CONF_FILE={{ aaa_jaas_krb5_conf_path }}
+{% endif %}
+{% if aaa_jaas_ticket_cache_path is defined %}
+AAA_JAAS_USE_TICKET_CACHE=true
+AAA_JAAS_TICKET_CACHE_FILE={{ aaa_jaas_ticket_cache_path }}
+{% endif %}
+{% if aaa_jaas_keytab_path is defined %}
+AAA_JAAS_USE_KEYTAB=true
+AAA_JAAS_KEYTAB_FILE={{ aaa_jaas_keytab_path }}
+{% endif %}

--- a/templates/profile
+++ b/templates/profile
@@ -13,6 +13,14 @@ pool.default.auth.simple.bindDN = ${global:vars.user}
 {% if aaa_password is defined %}
 pool.default.auth.simple.password = ${global:vars.password}
 {% endif %}
+{% if aaa_jaas_ticket_cache_path is defined or aaa_jaas_keytab_path is defined %}
+pool.authz.auth.type = gssapi
+pool.authz.auth.gssapi.jAASClientName = oVirtKerbAAA
+{% if aaa_profile_type == 'ad' %}
+pool.gc.auth.type = gssapi
+pool.gc.auth.gssapi.jAASClientName = oVirtKerbAAA
+{% endif %}
+{% endif %}
 {# ----------------- SRV record ----------------- #}
 {% if aaa_ldap_is_domain %}
 pool.default.serverset.type = srvrecord


### PR DESCRIPTION
Add kerberos authentication of LDAP queries
    
oVirt AAA can authenticate it's LDAP queries via kerberos using
either ticket cache or keytab since 4.0, this commit adds the
functionality to oVirt AAA LDAP role.

Modify package installation

construct 'yum package=string-*' matches first package (jdbc actually
that gets installed anyway in recent releases) while we need multiple
packages. This commit builds a list of packages depending on
whether we're installing SSO or not.